### PR TITLE
feat(navbar): add logic to disable button based on board columns

### DIFF
--- a/src/app/components/navbar/Navbar.jsx
+++ b/src/app/components/navbar/Navbar.jsx
@@ -11,13 +11,16 @@ import {useBoardCount} from "@/app/hooks/useBoardCount";
 
 const Navbar = () => {
 
-  const {isModalOpen, modalType, activateModal} = useStore(state => ({
+  const {isModalOpen, modalType, activateModal, boards, selectedBoardId} = useStore(state => ({
     isModalOpen: state.isModalOpen,
     modalType: state.modalType,
-    activateModal: state.activateModal
+    activateModal: state.activateModal,
+    boards: state.boards,
+    selectedBoardId: state.selectedBoardId
   }));
 
   const boardCount = useBoardCount();
+  const selectedBoardHasColumns = boards[selectedBoardId]?.columns && Object.keys(boards[selectedBoardId].columns).length > 0;
 
   return (
     <>
@@ -36,7 +39,7 @@ const Navbar = () => {
           </div>
           <div className="navgroup-2">
             <div className="add-task-container">
-              <CustomButton label={'+'} type={'primary-small'} id="add_task" disabled={false}/>
+              <CustomButton label={'+'} type={'primary-small'} id="add_task" disabled={boardCount=== 0 || !selectedBoardHasColumns}/>
             </div>
             <Image src={Vertical_Ellipsis} alt="Vertical Ellipsis"/>
           </div>

--- a/src/app/store/useStore.jsx
+++ b/src/app/store/useStore.jsx
@@ -1,20 +1,36 @@
 import create from 'zustand';
 
 const useStore = create((set, get) => ({
-  boards: {},
+  /*boards: {
+  *   board_id: {
+  *     title: '',
+  *     columns: {
+  *       column_id: {
+  *         title: '',
+  *         description: '',
+  *         subtasks: [],
+  *         current_state: ''
+  *     }
+  *     */
+  boards: {}, //object with all boards containing columns, subtasks, etc.
+  selectedBoardId: null, // id of the board currently being viewed
+
+  // UI state
   isDarkMode: false,
   isModalOpen: false,
+
+  // Modal state
   modalType: '',
 
   printBoard: () => console.log(get().state),
 
   getBoardAmount: () => Object.keys(get().boards).length,
 
-  toggleDarkMode: () => set((state) => ({ isDarkMode: !state.isDarkMode })),
+  toggleDarkMode: () => set((state) => ({isDarkMode: !state.isDarkMode})),
 
-  activateModal: (modalType) => set(() => ({ isModalOpen: true, modalType })),
+  activateModal: (modalType) => set(() => ({isModalOpen: true, modalType})),
 
-  closeModal: () => set(() => ({ isModalOpen: false, modalType: '' }))
+  closeModal: () => set(() => ({isModalOpen: false, modalType: ''}))
 }));
 
 export default useStore;


### PR DESCRIPTION
## Summary of Changes
- Implemented logic to disable the 'Add Task' button in the navbar when there are no columns present in the selected board.

## Motivation and Context
This change ensures a better user experience by preventing users from attempting to add tasks when there is no column to categorize them under.

## Description of Changes
- Added a conditional check in `Navbar` component to disable the button based on the state of `selectedBoardId` and its columns.
- Updated Zustand store to include necessary selectors for board and column information.

## How Has This Been Tested?
- Manual testing to confirm the button is disabled/enabled under correct conditions.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Additional Notes
Further testing on different devices recommended for UI consistency.
