### PR TITLE
Fix task status and edit

### DIFF
--- a/src/app/components/modal/task/taskform/TaskForm.jsx
+++ b/src/app/components/modal/task/taskform/TaskForm.jsx
@@ -101,6 +101,21 @@ const TaskForm = ({ mode }) => {
     }));
   }, []);
 
+
+  /**
+   * @function handleSelectStatus - Handles the selection of a new status for the task.
+   * @type {(function(*): void)|*}
+   * @param {Object} menuItem - The selected status menu item.
+   * @returns {void}
+   */
+  const handleSelectStatus = useCallback((menuItem) => {
+    // create a new task object with the updated status
+    setTaskData(prevData => ({
+      ...prevData,
+      status: menuItem
+    }));
+  } , []);
+
   /**
    * @function handleSubmitTask - Handles form submission, validates fields, and sets error messages.
    * @param {Object} e - The event object.
@@ -144,6 +159,7 @@ const TaskForm = ({ mode }) => {
         createTask(newTask);
       }
       closeModal();
+      console.log(activeBoard)
     }
   };
 
@@ -196,7 +212,7 @@ const TaskForm = ({ mode }) => {
           onClick={addSubtask}
         />
 
-        <Menu newTask={taskData} handleSelectStatus={setTaskData} />
+        <Menu newTask={taskData} handleSelectStatus={handleSelectStatus} />
 
         <CustomButton
           label={`${mode !== 'edit' ? 'Create Task' : 'Save Changes'}`}

--- a/src/app/store/useStore.jsx
+++ b/src/app/store/useStore.jsx
@@ -149,15 +149,26 @@ const useStore = create((set, get) => ({
         break;
 
       case 'edit':
-        // Replace the old task with the updated task
+        const oldStatus = state.initialData.status;
+        const newStatus = updatedTask.status;
+
         updatedActiveBoard = {
           ...state.activeBoard,
-          columns: state.activeBoard.columns.map((column) => ({
-            ...column,
-            tasks: column.tasks.map((task) =>
-              task.name === state.initialData.name ? updatedTask : task
-            ),
-          })),
+          columns: state.activeBoard.columns.map((column) => {
+            if (column.name === oldStatus) {
+              return {
+                ...column,
+                tasks: column.tasks.filter((task) => task.name !== state.initialData.name),
+              };
+            }
+            if (column.name === newStatus) {
+              return {
+                ...column,
+                tasks: [...column.tasks, updatedTask],
+              };
+            }
+            return column;
+          }),
         };
         break;
 


### PR DESCRIPTION
# Fix task status and edit

## Description
- When in the task summary, selecting the same status in the menu creates a duplicate of that task
- When editing the status from the task edit modal, saving does not move the task to the appropriate column

## Changes
- modified`useStore` to allow proper saving of updated status when editing or selecting the status from the task summary view

## Solved Issues
- Closes #14

